### PR TITLE
Hardcode Ect/GMT for passed times, expecting UTC dates

### DIFF
--- a/ics.template
+++ b/ics.template
@@ -10,8 +10,8 @@ UID:<%= uid %>
 DTSTART;VALUE=DATE:<%= startDate %>
 DTEND;VALUE=DATE:<%= endDate %>
 <% } else { %>
-DTSTART;TZID=<%= timezone %>:<%= startDate %>
-DTEND;TZID=<%= timezone %>:<%= endDate %>
+DTSTART;TZID=Etc/GMT:<%= startDate %>
+DTEND;TZID=Etc/GMT:<%= endDate %>
 <% } %>
 SUMMARY:<%= summary %>
 DESCRIPTION:<%= description %>


### PR DESCRIPTION
Some background: since the origin of the ICS generator, we've had:

`X-WR-TIMEZONE:<%= timezone %>`

and

```
DTSTART;TZID=<%= timezone %>:<%= startDate %>
DTEND;TZID=<%= timezone %>:<%= endDate %>
```

in the template file. The `<%= timezone% =>` in `X-WR-TIMEZONE` would localize the start time to the recipient's timezone, and the `<%= timezone% =>` in `DSTART` and `DTEND` were the timezones that the event was taking place in.

This never raised any red flags, as most of our clients would use this app to notify their customers of events in their old timezone (e.g. East coast companies would be planning east coast events for east coast customers). 

However, this became a problem when the event was in a certain timezone (say, JST in Japan), and recipients included people in Europe and the Americas. Because we were passing the same value in both fields, this would render as the incorrect time in the calendar.

It seems like the best option at the moment, given the issues of `Add-to-Cal` and https://github.com/movableink/studio-add-to-calendar/pull/4, is to always pass the event time in a standardized, UTC format. Thus, the change here would be that we always anticipate a UTC formatted timezone moving forward.