### PR TITLE
Kr/ics name customization

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,10 +58,10 @@ function formatDate(d) {
   return d.getFullYear() + pad2(d.getMonth() + 1) + pad2(d.getDate());
 };
 
-function sanitizeFileName(n) {
+function sanitizeFileName(filename) {
   let result = '';
   const isValidChar = new RegExp(/[A-Za-z0-9_\-\.]/);
-  for (let char of n) {
+  for (let char of filename) {
     if (isValidChar.test(char)) { result += char }
   }
   return result;

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ http.createServer(function(req, res) {
 
   options.uid = (new Date()).getTime() + "@" + host;
   options.now = formatDate(new Date());
+  options.fileName = sanitizeFileName(options.fileName);
 
   var output = template(options);
 
@@ -56,6 +57,15 @@ function formatDatetime(d) {
 function formatDate(d) {
   return d.getFullYear() + pad2(d.getMonth() + 1) + pad2(d.getDate());
 };
+
+function sanitizeFileName(n) {
+  let result = '';
+  const isValidChar = new RegExp(/[A-Za-z0-9_\-\.]/);
+  for (let char of n) {
+    if (isValidChar.test(char)) { result += char }
+  }
+  return result;
+}
 
 function pad2(i) {
   if(i < 10) {

--- a/index.js
+++ b/index.js
@@ -39,7 +39,6 @@ http.createServer(function(req, res) {
   options.now = formatDate(new Date());
 
   var output = template(options);
-  console.log('its working');
 
   res.writeHead(200, {
     'Content-Type': 'text/calendar',

--- a/index.js
+++ b/index.js
@@ -19,8 +19,13 @@ http.createServer(function(req, res) {
     location: params.location,
     name: params.name,
     allDay: params.all_day,
+    fileName: params.file_name,
     rrule: params.rrule
   };
+
+  if (!options.fileName || !options.fileName.length) {
+    options.fileName = 'Event';
+  }
 
   if (options.allDay) {
     options.startDate = formatDate(new Date(params.start));
@@ -34,8 +39,12 @@ http.createServer(function(req, res) {
   options.now = formatDate(new Date());
 
   var output = template(options);
+  console.log('its working');
 
-  res.writeHead(200, {'Content-Type': 'text/calendar'});
+  res.writeHead(200, {
+    'Content-Type': 'text/calendar',
+    'Content-Disposition': `attachment; filename="${options.fileName}.ics"`
+  });
   res.end(output);
 }).listen(port);
 

--- a/index.js
+++ b/index.js
@@ -59,12 +59,7 @@ function formatDate(d) {
 };
 
 function sanitizeFileName(filename) {
-  let result = '';
-  const isValidChar = new RegExp(/[A-Za-z0-9_\-\.]/);
-  for (let char of filename) {
-    if (isValidChar.test(char)) { result += char }
-  }
-  return result;
+  return filename.replace(/[^A-Za-z0-9_\-\.]/, ()=>'');
 }
 
 function pad2(i) {


### PR DESCRIPTION
Current Behavior
No filename is set for the ics generated

Why do we need this change?
Clients would like to be able to change the name of the file generated by our Add to Calendar app to something more relevant to their campaigns.

Implementation Details
Sets file name to params.file_name. If no file name was set, it defaults to "Event".

Dependencies (if any)

*  goes with https://github.com/movableink/studio-apps/pull/16
[:house: [ch11793]](https://app.clubhouse.io/movableink/story/11793)
