### PR TITLE
Santitizes filename first

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,9 +33,8 @@ http.createServer(function(req, res) {
 
   options.uid = (new Date()).getTime() + "@" + host;
   options.now = formatDate(new Date());
-  options.fileName = sanitizeFileName(options.fileName);
-
-  if (!options.fileName || !options.fileName.length) {
+  options.fileName = sanitizeFileName(options.fileName || '');
+  if (!options.fileName.length) {
     options.fileName = 'Event';
   }
 

--- a/index.js
+++ b/index.js
@@ -23,10 +23,6 @@ http.createServer(function(req, res) {
     rrule: params.rrule
   };
 
-  if (!options.fileName || !options.fileName.length) {
-    options.fileName = 'Event';
-  }
-
   if (options.allDay) {
     options.startDate = formatDate(new Date(params.start));
     options.endDate = params.end ? formatDate(new Date(params.end)) : options.startDate;
@@ -38,6 +34,10 @@ http.createServer(function(req, res) {
   options.uid = (new Date()).getTime() + "@" + host;
   options.now = formatDate(new Date());
   options.fileName = sanitizeFileName(options.fileName);
+
+  if (!options.fileName || !options.fileName.length) {
+    options.fileName = 'Event';
+  }
 
   var output = template(options);
 


### PR DESCRIPTION
Checks the length of the filename after its sanitized.
For edge cases where user enters an invalid filename (i.e. "^^&&*&@^#" )

https://app.clubhouse.io/movableink/story/11793/ability-to-customize-the-name-of-ics-files-generated-by-the-add-to-calendar-app