### PR TITLE
Adds global char to regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ function formatDate(d) {
 };
 
 function sanitizeFileName(filename) {
-  return filename.replace(/[^A-Za-z0-9_\-\.]/, ()=>'');
+  return filename.replace(/[^A-Za-z0-9_\-\.]/g, ()=>'');
 }
 
 function pad2(i) {


### PR DESCRIPTION
Regex wasn't doing a global search for invalid characters. 
Therefore was only replacing the first instance.