### PR TITLE
keep new line chars

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ http.createServer(function(req, res) {
     host: host,
     timezone: params.tz,
     summary: params.summary,
-    description: params.description,
+    description: params.description.replace(/\n/gi, "\\n"),
     location: params.location,
     name: params.name,
     allDay: params.all_day,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "ics-generator",
+  "version": "0.0.0",
+  "lockfileVersion": 1,
+  "dependencies": {
+    "underscore": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
+    }
+  }
+}


### PR DESCRIPTION
## Current Behavior
Calendar Apps (specifically iCal) strips away all text that comes after the first line break character in the description portion of an ics file. As a result of this, entire text including special characters are ignored after a line break in calendar apps (iCal, Outlook etc).

## Why do we need this change?
Clients often have large amounts of copy they'd like to include in the description of the calendar invite and would like to be able to insert line breaks and other special characters.

## Implementation Details
The workaround is to replace line break characters with escaped line break characters.

:house: [ch11700](https://app.clubhouse.io/movableink/story/11700)
